### PR TITLE
feat: use lto/cogegen=1 to reduce binary size

### DIFF
--- a/ext/pgp_rb/Cargo.toml
+++ b/ext/pgp_rb/Cargo.toml
@@ -12,3 +12,7 @@ num-traits = "0.2.18"
 
 [lib]
 crate-type = ["cdylib"]
+
+[profile.release]
+lto = true
+codegen-units = 1


### PR DESCRIPTION
Add release profile to do better optimization

* LTO = link time optimization (better linking for exchange of higher memory usage during linking)
* `codegen-units=1` cause slower compilation (in release mode), but give more chances for optimization.

Result (for non-stripped .so):

From  4918680 to 2581168 bytes