### PR TITLE
Bump dependencies and libs to support ruby 3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ source 'https://rubygems.org'
 
 gem 'base64'
 gem 'bundler'
+gem 'ostruct'
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pgp-rb (0.2.1)
+    pgp-rb (0.2.2)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
     json (2.7.1)
     language_server-protocol (3.17.0.3)
     method_source (1.0.0)
+    ostruct (0.6.3)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -69,6 +70,7 @@ PLATFORMS
 DEPENDENCIES
   base64
   bundler
+  ostruct
   pgp-rb!
   pry
   rake-compiler (~> 1.2)

--- a/ext/pgp_rb/Cargo.lock
+++ b/ext/pgp_rb/Cargo.lock
@@ -1401,18 +1401,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.117"
+version = "0.9.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f900d1ce4629a2ebffaf5de74bd8f9c1188d4c5ed406df02f97e22f77a006f44"
+checksum = "c85c4188462601e2aa1469def389c17228566f82ea72f137ed096f21591bc489"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.117"
+version = "0.9.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1e9c857028f631056bcd6d88cec390c751e343ce2223ddb26d23eb4a151d59"
+checksum = "568068db4102230882e6d4ae8de6632e224ca75fe5970f6e026a04e91ed635d3"
 dependencies = [
  "bindgen",
  "lazy_static",

--- a/ext/pgp_rb/Cargo.lock
+++ b/ext/pgp_rb/Cargo.lock
@@ -987,9 +987,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "magnus"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d87ae53030f3a22e83879e666cb94e58a7bdf31706878a0ba48752994146dab"
+checksum = "3b36a5b126bbe97eb0d02d07acfeb327036c6319fd816139a49824a83b7f9012"
 dependencies = [
  "magnus-macros",
  "rb-sys",
@@ -999,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "magnus-macros"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5968c820e2960565f647819f5928a42d6e874551cab9d88d75e3e0660d7f71e3"
+checksum = "47607461fd8e1513cb4f2076c197d8092d921a1ea75bd08af97398f593751892"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1425,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "rb-sys-env"
-version = "0.1.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35802679f07360454b418a5d1735c89716bde01d35b1560fc953c1415a0b3bb"
+checksum = "cca7ad6a7e21e72151d56fe2495a259b5670e204c3adac41ee7ef676ea08117a"
 
 [[package]]
 name = "regex"

--- a/ext/pgp_rb/Cargo.toml
+++ b/ext/pgp_rb/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 [dependencies]
 pgp = "0.16.0"
 rand = "0.8.5"
-magnus = "0.7.1"
+magnus = "0.8.2"
 base64 = "0.22.1"
 num-traits = "0.2.19"
 chrono = "0.4"
-rb-sys = { version = "0.9.117", features = ["ruby-static"] }
+rb-sys = { version = "0.9.124", features = ["ruby-static"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/lib/pgp-rb/version.rb
+++ b/lib/pgp-rb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PGP
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/pgp-rb.gemspec
+++ b/pgp-rb.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.version = PGP::VERSION
   spec.summary = 'rPGP ruby wrapper'
   spec.files = Dir['lib/**/*.rb', 'ext/**/*.{rs,toml,lock,rb}']
-  spec.extensions = ['ext/pgprb/extconf.rb']
+  spec.extensions = ['ext/pgp_rb/extconf.rb']
   spec.rdoc_options = ['--main', 'README.rdoc', '--charset', 'utf-8', '--exclude', 'ext/']
   spec.authors = ['Kirill Zaitsev']
   spec.email = ['kirik910@gmail.com']


### PR DESCRIPTION
## Summary
 - Bump gem version from 0.2.1 to 0.2.2
 - Update `rb-sys` / `rb-sys-build` from 0.9.117 to 0.9.124 for Ruby 3.4 compatibility
 - Fix gemspec extension path from `ext/pgprb/extconf.rb` to `ext/pgp_rb/extconf.rb`

 ## Changed Files
 - `lib/pgp-rb/version.rb` — version bump 0.2.1 → 0.2.2
 - `pgp-rb.gemspec` — fix extension path (underscore)
 - `ext/pgp_rb/Cargo.lock` — rb-sys dependency update
 - `Gemfile.lock` — reflects new version
